### PR TITLE
Enable svelte store in webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,7 +50,7 @@ module.exports = {
             {
                 test: /\.svelte$/,
                 exclude: /node_modules/,
-                use: 'svelte-loader'
+                use: {loader: 'svelte-loader', options: {store: true}}
             },
 
             {


### PR DESCRIPTION
Enables svelte's store in svelte-loader's options. From the svelte docs:
To tell Svelte that you're going to be using Store, you must pass the store: true compiler option. This will change in version 2, when the compiler will automatically generate store-aware components.