### PR TITLE
Include node_modules/svelte in babel loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@itslearning/protomorph",
     "description": "Shared build config for frontend applications",
-    "version": "7.0.2",
+    "version": "7.0.3",
     "author": "Gavin King <gavin.king@itslearning.com>",
     "license": "MIT",
     "scripts": {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -83,7 +83,7 @@ module.exports = {
                 // If you need to transpile any npm modules, you will need
                 // to create your own exclude value
                 // @see https://github.com/babel/babel-loader/issues/171
-                exclude: new RegExp('node_modules\\' + path.sep + '(?!@itslearning)')
+                exclude: new RegExp('node_modules\\' + path.sep + '(?![@itslearning|svelte])')
             },
 
             {


### PR DESCRIPTION
Since v2 Svelte has moved past ES5 making it incompatible with some browsers without using a transpiler. This change includes the svelte folder in the webpack babel loader to be transpiled along with our own js.