### PR TITLE
We want exact versions to be used to improve predictability for consumers.

### DIFF
--- a/.yarnrc
+++ b/.yarnrc
@@ -1,0 +1,1 @@
+save-prefix ""


### PR DESCRIPTION
The .yarnrc entry will prevent the caret () prefix when saving an entry to the package.json.

This means that the versions we install should be the exact same on every install with that package.json file.