### PR TITLE
Make itsl rollup less magical

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+## [v9.9.0] - 02.10.2019
+
 - export sass/svelte from itsl.rollup
 
 ## [v9.8.0] - 30.08.2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- export sass/svelte from itsl.rollup
+
 ## [v9.8.0] - 30.08.2019
 
 ### Changed

--- a/itsl.rollup.js
+++ b/itsl.rollup.js
@@ -97,5 +97,7 @@ const ItslRollup = ({ destination, files, plugins = {} }) =>
     });
 
 module.exports = {
-    ItslRollup
+    ItslRollup,
+    Svelte,
+    Sass
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@itslearning/protomorph",
     "description": "Shared build config for frontend applications",
-    "version": "9.8.0",
+    "version": "9.9.0",
     "author": "Itslearning AS",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
Export Svelte/Sass method from itsl.rollup in a first phase to remove the magical properties of the script