### PR TITLE
Fix core-js issue 'delete includes in strict mode'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Downgraded core-js to v3.6.1 to fix IE11 compatibility issue
+
 ## [v10.4.1] - 17.02.2020
 
-## Fixed
+### Fixed
 
 - Fixed rollup module bundle for edge support
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "@babel/plugin-proposal-object-rest-spread": "7.8.3",
         "@babel/preset-env": "7.8.3",
         "whatwg-fetch": "^3.0.0",
-        "core-js": "3.6.4",
+        "core-js": "3.6.1",
         "regenerator-runtime": "^0.13.3",
         "@types/chai": "4.1.3",
         "@types/mocha": "5.2.0",


### PR DESCRIPTION
Fixes an issue caused by core-js 3.6.2 that makes the 'Array.includes'
polyfill to attempt to delete the existing Array.includes implementation which is
not allowed in strict mode and causes a runtime error when its run
in IE11. Until we can resolve why this happens we should use 3.6.1.

The root cause is likely in our implementation, I suspect we are polyfilling Array.includes somewhere else and the second attempt is trying to delete the first attempt's polyfill.