### PR TITLE
Internal changes: Update to whatwg-fetch v3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v10.11.1] - 01.10.2020
+
 ### Changed
 
 - Internal changes: Update to whatwg-fetch v3.4.1. Fixes warning due to calling `this` on global level which is undefined.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Internal changes: Update to whatwg-fetch v3.4.1. Fixes warning due to calling `this` on global level which is undefined.
+
 ## [v10.11.0] - 14.08.2020
 
 ### Changed
@@ -20,7 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Internal changes: Update to karma-mocha v2.0.1
 - Internal changes: Update to node-sass v4.14.0
-- Internal changes: Update to  optimize-css-assets-webpack-plugin to v5.0.3
+- Internal changes: Update to optimize-css-assets-webpack-plugin to v5.0.3
 
 ## [v10.9.0] - 04.08.2020
 

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
         "webpack": "4.44.1",
         "webpack-clean": "1.2.3",
         "webpack-cli": "3.3.10",
-        "whatwg-fetch": "^3.0.0"
+        "whatwg-fetch": "3.4.1"
     },
     "resolutions": {
         "acorn": "^7.1.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@itslearning/protomorph",
     "description": "Shared build config for frontend applications",
-    "version": "10.11.0",
+    "version": "10.11.1",
     "author": "Itslearning AS",
     "license": "MIT",
     "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -8336,10 +8336,10 @@ webpack@4.44.1:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-whatwg-fetch@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
+whatwg-fetch@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.4.1.tgz#e5f871572d6879663fa5674c8f833f15a8425ab3"
+  integrity sha512-sofZVzE1wKwO+EYPbWfiwzaKovWiZXf4coEzjGP9b2GBVgQRLQUZ2QcuPpQExGDAW5GItpEm6Tl4OU5mywnAoQ==
 
 which-module@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Fixes warning from Rollup due to whatwg-fetch calling `this` on global level which is undefined.