### PR TITLE
Plugins collection to use before standard collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [v11.0.0-beta.8] - 18.11.2022
+
+### Changed
+
+- `Sass` and `Svelte` configuration objects now support plugins (`beforePlugins`) that are being applied BEFORE standard plugins.  
 
 ## [v11.0.0-beta.7] - 23.08.2022
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [v11.0.0-beta.8] - 18.11.2022
 
 ### Changed
 

--- a/itsl.rollup.js
+++ b/itsl.rollup.js
@@ -13,6 +13,7 @@ const json = require('@rollup/plugin-json');
 const defaultOptions = {
     legacy: false,
     webComponents: false,
+    beforePlugins: [],
     plugins: [],
     eslint: {
         configFile: 'node_modules/@itslearning/protomorph/.eslintrc.json',
@@ -38,6 +39,7 @@ const Svelte = (src, dest, options = defaultOptions) => ({
     },
     treeshake: true,
     plugins: [
+        ...options.beforePlugins || defaultOptions.beforePlugins,
         eslint(options.eslint || defaultOptions.eslint),
         // @ts-ignore
         svelte(),
@@ -50,6 +52,7 @@ const Svelte = (src, dest, options = defaultOptions) => ({
 });
 
 const sassOptions = {
+    beforePlugins: [],
     plugins: [],
 };
 
@@ -71,6 +74,7 @@ const Sass = (src, dest, options = sassOptions) => ({
     // Script will ALWAYS render an empty file at first, ignore EMPTY_BUNDLE
     onwarn: (warning, onwarn) => warning.code === 'EMPTY_BUNDLE' || onwarn(warning),
     plugins: [
+        ...options.beforePlugins || sassOptions.beforePlugins,
         scss({
             sass: require('sass'),
             importer(path) {
@@ -89,7 +93,7 @@ const Sass = (src, dest, options = sassOptions) => ({
              */
             writeBundle: () => fs.renameSync(`${dest}.temp`, dest)
         },
-        ...options.plugins || []
+        ...options.plugins || sassOptions.plugins
     ]
 });
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@itslearning/protomorph",
     "description": "Shared build config for frontend applications",
-    "version": "11.0.0-beta.7",
+    "version": "11.0.0-beta.8",
     "author": "Itslearning AS",
     "license": "MIT",
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@itslearning/protomorph",
     "description": "Shared build config for frontend applications",
-    "version": "11.0.0-beta.8",
+    "version": "11.0.0-beta.7",
     "author": "Itslearning AS",
     "license": "MIT",
     "scripts": {


### PR DESCRIPTION
Make it possible to run custom plugins in Sass and Svelte objects before standard plugins collection

Closes #113 